### PR TITLE
Formatting markdown fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
-#extended javascript console#
+# extended javascript console #
 
-
-##better JavaScript console methods.##
+## better JavaScript console methods. ##
 ![Welcome](https://lh5.googleusercontent.com/-xDUxoBivJfk/VG5u4e3etHI/AAAAAAAAKsw/E8kA8YnS8Nc/w469-h263-no/Screen%2BShot%2B2014-11-20%2Bat%2B4.43.21%2BPM.png "Welcome")
 
 <hr>
-###contents###
+
+### contents ###
 <ol>
 	<li><a href="#getting-started">Getting Started</a></li>
 	<li><a href="#consoleout">console.out()</a></li>
@@ -19,7 +19,8 @@
 </ol>
 
 <hr>
-###getting started###
+
+### getting started ###
 xcon works as a require module or as a pojo.  There is also a browser extension that will automagically load the latest xcon-min release build to any page.  The extensions are still new and need to be field-tested more extensively, but I believe that this are the most logical way to deploy the latest xcon builds so that you don't have to touch your source code.
 
 * ![chrome](https://raw.githubusercontent.com/alrra/browser-logos/master/chrome/chrome_16x16.png "chrome") <a href="https://chrome.google.com/webstore/detail/extended-js-console/ieoofkiofkkmikbdnmaoaemncamdnhnd?hl=en&gl=US">Chrome Extension</a></li>
@@ -48,7 +49,7 @@ plain ol' JavaScript:
 ```
 <hr>
 
-###console.out()###
+### console.out() ###
 like `console.log`, but also prints the primitive type.  Accepts any number of arguments.  The last argument can contain an options hash.
 
 ```js
@@ -84,7 +85,8 @@ object:
 ```
 
 <hr width="50%">
-####options####
+
+#### options ####
 ```js
 var someVar = {"foo": "bar"};
 console.out(someVar, { // options hash is passed last
@@ -95,10 +97,11 @@ console.out(someVar, { // options hash is passed last
 ```
 <hr>
 
-###console.run()###
+### console.run() ###
 calls the given function; returns and logs the result with important details.  Catches errors gracefully and logs the error message.  Capable of nested calls for more complex debugging and logging.  Green text indicates that the function was run and returned a valid result.  Black text indicates that you are not invoking a function.  Red text indicates an error has occurred.
 
 <hr width="50%">
+
 ```js
 function goodFunction () {
 	return "this function worked!";
@@ -108,6 +111,7 @@ console.run(goodFunction);
 ![valid output](https://lh6.googleusercontent.com/-MrklrzynTyk/VG60Yoj1PfI/AAAAAAAAKtI/1LE4bqArAsE/w468-h54-no/Screen%2BShot%2B2014-11-20%2Bat%2B9.40.09%2BPM.png "Success")
 
 <hr width="50%">
+
 ```js
 function badFunction () {
 	return undefinedVariable;
@@ -117,7 +121,8 @@ console.run(badFunction);
 ![error output](https://dl.dropboxusercontent.com/u/10976600/xcon/undefined%20error.png "Error")
 
 <hr width="50%">
-####passing arguments####
+
+#### passing arguments ####
 Pass all function arguments as an array as the second argument.
 ```js
 function multiply () {
@@ -132,7 +137,8 @@ console.run(multiply, [2, 2, 2]);
 ![arguments](https://lh4.googleusercontent.com/-EOH07rgIGqA/VG609d5aFwI/AAAAAAAAKtY/EHw1EqHLIrE/w463-h46-no/Screen%2BShot%2B2014-11-20%2Bat%2B9.43.24%2BPM.png "Arguments")
 
 <hr width="50%">
-####passing context####
+
+#### passing context ####
 ```js
 var fakeObj = {};
 function FakeConstructor () {
@@ -146,7 +152,8 @@ fakeObj.prop === "something"; // true
 in the above example, `fakeObj` will be interpreted as `this` by `FakeConstructor'.
 
 <hr width="50%">
-####nesting calls####
+
+#### nesting calls ####
 sometimes it helps to know what a chain of dependent functions are doing.  Because console.run() returns the value of the function, you can keep eye on the output of each function in an organized way.
 ```js
 function mcConaughey (article) {
@@ -155,7 +162,7 @@ function mcConaughey (article) {
 function carrey (topic) {
 	return "makes a joke about " + topic;
 }
-console.run(carrey, 
+console.run(carrey,
 	[console.run(mcConaughey, ["shirt"])]
 );
 ```
@@ -177,7 +184,8 @@ console.run(carrey,
 ![chain undefined](https://lh6.googleusercontent.com/-n3olWEE3yO8/VG63A8H-6cI/AAAAAAAAKuo/u44gRCu6w-0/w458-h112-no/Screen%2BShot%2B2014-11-20%2Bat%2B9.52.17%2BPM.png "Chain Debugging")
 
 <hr width="50%">
-####Non-functions####
+
+#### Non-functions ####
 It is possible to pass a non-function into `.run()`.  The value of that non-function will be logged as though you were calling `.out()`.  Additionally, that non-function will be returned, enabling the developer to write inline console statements.
 ```js
 var a = console.run('a');
@@ -187,12 +195,15 @@ a === 'a' // evaluates to true
 // a
 ```
 <hr>
-###console.expect()###
-####unit tests in the browser console####
+
+### console.expect() ###
+
+#### unit tests in the browser console ####
 A stripped-down collection of unit test methods that borrow heavily from <a href="http://jasmine.github.io/">jasmine.js</a>.  Developers who regularly use console.log() to debug or dirty-test their code may find that console.expect adds a more precise tool to their workflow.
 
 <hr width="50%">
-####console.expect(data).toEqual(comparison)####
+
+#### console.expect(data).toEqual(comparison) ####
 A passed test indicates that the argument passed to `expect()` and the argument passed to `toEqual()` are strictly equal - including truthy and falsy values.  Works for any JavaScript data type: primitives, objects, and functions.  Test results are highlighted in green (passed) or red (failed) in the console.
 ```js
 console.expect(4).toEqual(4);
@@ -200,7 +211,8 @@ console.expect(4).toEqual(4);
 ![toEqual](https://lh3.googleusercontent.com/-5h11iNoLwKM/VG63SifSbiI/AAAAAAAAKu8/Ng9OGwxRPng/w457-h27-no/Screen%2BShot%2B2014-11-20%2Bat%2B9.53.29%2BPM.png ".toEqual")
 
 <hr width="50%">
-####Failed isEqual() tests####
+
+#### Failed isEqual() tests ####
 Failed isEqual() tests will call <a href="#consolediff">console.diff()</a> if both inputs are objects or both are arrays.
 ```js
 console.expect({
@@ -212,7 +224,8 @@ console.expect({
 ![failed-object-equality](https://lh3.googleusercontent.com/-vBdj9CLmmPI/VIcOjqQsKCI/AAAAAAAALuM/ycjHzbKyc8E/w432-h96-no/Screen%2BShot%2B2014-12-09%2Bat%2B8.56.16%2BAM.png "failed-object-equality")
 
 <hr width="50%">
-####console.expect(data).toContain(comparison)####
+
+#### console.expect(data).toContain(comparison) ####
 Passed test indicates that data (can be an object or array) contains comparison anywhere in its structure.  This works for complex arrays and objects with nested data.
 ```js
 var complexObj = {
@@ -239,7 +252,8 @@ console.expect(complexObj).toContain(6);
 ![toContain](https://lh4.googleusercontent.com/-KxrFJ7c62dI/VI9OhmORV9I/AAAAAAAAL0c/TWHbkl0BisQ/w805-h47-no/Screen%2BShot%2B2014-12-15%2Bat%2B3.11.13%2BPM.png ".toContain")
 
 <hr width="50%">
-####console.expect(data).toBeCloseTo(num, margin)####
+
+#### console.expect(data).toBeCloseTo(num, margin) ####
 Passed test indicates that num will be greater than data - margin and less than data + margin.
 ```js
 console.expect(5).toBeCloseTo(6, 2);
@@ -247,7 +261,8 @@ console.expect(5).toBeCloseTo(6, 2);
 ![toBeCloseTo](https://lh5.googleusercontent.com/-le5xm_nXnPc/VI9NewjfPFI/AAAAAAAAL0M/KvG9vkj1MLM/w438-h18-no/Screen%2BShot%2B2014-12-15%2Bat%2B3.06.55%2BPM.png ".toBeCloseTo")
 
 <hr width="50%">
-####console.expect(data).toBeTruthy()####
+
+#### console.expect(data).toBeTruthy() ####
 Passed test indicates a <a href="http://www.codeproject.com/Articles/713894/Truthy-Vs-Falsy-Values-in-JavaScript">truthy</a> value.
 ```js
 console.expect("I'm truthy").toBeTruthy();
@@ -255,7 +270,8 @@ console.expect("I'm truthy").toBeTruthy();
 ![toBeTruthy](https://lh6.googleusercontent.com/-hMWfjYtvuNM/VG63kNn_N6I/AAAAAAAAKvI/fHPtSHnb02I/w350-h21-no/Screen%2BShot%2B2014-11-20%2Bat%2B9.54.40%2BPM.png ".toBeTruthy")
 
 <hr width="50%">
-####console.expect(data).toBeDefined()####
+
+#### console.expect(data).toBeDefined() ####
 Passed test indicates data that is not undefined.
 ```js
 console.expect({}).toBeDefined();
@@ -263,7 +279,8 @@ console.expect({}).toBeDefined();
 ![toBeDefined](https://lh5.googleusercontent.com/-Dv7-tHpNsck/VG64PFuQkQI/AAAAAAAAKvo/C45le3SmgGA/w302-h22-no/Screen%2BShot%2B2014-11-20%2Bat%2B9.57.25%2BPM.png ".toBeDefined")
 
 <hr width="50%">
-####console.expect(data).toBeNull()####
+
+#### console.expect(data).toBeNull() ####
 Passed test indicates data that is equal to `null`.
 ```js
 console.expect(null).toBeNull();
@@ -271,7 +288,8 @@ console.expect(null).toBeNull();
 ![toBeNull](https://lh4.googleusercontent.com/-dw0bUdGZoLk/VI9MipN3yhI/AAAAAAAALz8/_2n21vsJLag/w274-h18-no/Screen%2BShot%2B2014-12-15%2Bat%2B3.01.34%2BPM.png ".toBeNull")
 
 <hr width="50%">
-####.not####
+
+#### .not ####
 Prepend the test method with .not to invert the test.
 ```js
 console.expect(Math.PI).not.toEqual(Math.PI);
@@ -286,7 +304,8 @@ console.expect([0, 1, 2]).not.toEqual({"0": 0, "1": 1, "2": 2});
 <em>Note: JavaScript would interpret these two blobs as identical because they are both objects, have identical keys and values.  For the purposes of testing, it is anticipated that developers would not want an array and object to be considered stricty equal for the purpose of testing code.  Furthermore, arrays and objects have different prototypes.  For these reasons, arrays and objects with identical keys and values will not be interpreted by xcon as equal.</em>
 
 <hr>
-###console.diff()###
+
+### console.diff() ###
 Given two objects or two arrays, tells the user whether the two arguments are equal and, if not, exactly what unique data is in each argument.  Will return false if the types of both arguments do not match or if given a non-object or non-array as an argument.  Works for nested objects and arrays, as well.  This method is automatically called when there is a failed isEqual() test in <a href="#consoleexpect">console.expect()</a>.
 
 ```js
@@ -306,15 +325,16 @@ console.diff(harry, lloyd);
 ```
 ![console.diff](https://lh6.googleusercontent.com/-QUb1LCGN3LQ/VIcOjTKilqI/AAAAAAAALuI/4YIvF34eZ3k/w230-h78-no/Screen%2BShot%2B2014-12-09%2Bat%2B8.57.02%2BAM.png "console.diff")
 <hr>
-###Namespace###
+
+### Namespace ###
 To ensure that xcon.js will never break native console methods, there are fallbacks in the code.  If Mozilla, Webkit, Microsoft, etc. were to implement .run, .out, .diff, or .expect tomorrow, xcon would not overwrite those methods.
 <hr>
 
-###Tests###
+### Tests ###
 `grunt jasmine` will run the tests in the command line.  Jasmine unit tests are in the `tests` directory.
 <hr>
 
-###Contribute###
+### Contribute ###
 The `package.json` file is kept up-to-date and should contain all dev dependencies needed.  `grunt build` runs all test specs in the command line and will abort if any tests are broken.
 
 <a href="https://github.com/wecodemore/grunt-githooks">Grunt githooks</a> is a dev dependency and will run all jasmine unit tests on every commit.  To enable the git commit hook (please do), `grunt githooks`.  Do not skip the hook!
@@ -322,5 +342,5 @@ The `package.json` file is kept up-to-date and should contain all dev dependenci
 Xcon source and test files use AMD modules via <a href="http://requirejs.org/">require.js</a>.  <a href="http://gruntjs.com/">Grunt</a>, <a href="https://github.com/gfranko/amdclean">AMDclean</a>, and <a href="https://github.com/gruntjs/grunt-contrib-uglify">uglify</a> are used to create production builds that do not need AMD.  The project makes use of release branching for new features.  See the <a href="https://github.com/bignimbus/extended-javascript-console/issues">issues</a> section for project milestones.
 <hr>
 
-###Acknowledgements###
+### Acknowledgements ###
 Thanks to <a href="https://github.com/kurtpeters">Kurt Peters</a> and <a href="https://github.com/cswagerty">Corbin Swagerty</a>, both of whom offered some great ideas for this project.  <a href="https://github.com/tanzeelkazi">Tanzeel Kazi</a> also made important contributions to the expectation module.


### PR DESCRIPTION
Update headers to include spaces and preceding blank line so formatting of readme on github.com works better and is more readable.